### PR TITLE
Remove aiobotocore

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.9
   - ipykernel
   - echopype=0.5.4
-  - aiobotocore
   - geopandas
   - cartopy
   # -- holoviz --

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.9
   - ipykernel
   - echopype=0.5.4
+  - s3fs=2021.10.1
   - geopandas
   - cartopy
   # -- holoviz --


### PR DESCRIPTION
Seems like `aiobotocore` is causing issue when listed here. Removing it would be best since it's already getting pulled from the latest s3fs. Otherwise, this will cause the latest aiobotocore to be pulled and an older version of s3fs, that causes an issue when running the echopype_tour notebook.