### PR TITLE
Update notebook/chapter titles

### DIFF
--- a/notebooks/ms_PacificHake_EK60_cruisetracks.ipynb
+++ b/notebooks/ms_PacificHake_EK60_cruisetracks.ipynb
@@ -4,8 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Echopype demonstration notebook 1\n",
-    "## Exploring ship echosounder data from the Pacific Hake survey"
+    "# Exploring ship echosounder data from the Pacific Hake survey"
    ]
   },
   {
@@ -5957,7 +5956,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.0"
   },
   "toc-autonumbering": true
  },


### PR DESCRIPTION
The notebook titles are shown as book chapter titles, and it is a bit weird to have "2. Echopype demonstration notebook 1" and "3. Echopype demonstration notebook 2". 

The titles were that way before there's an "echopype tour" notebook. I think we can now do without the notebook number. :) 

(Update on this repo never ends...!)