### PR TITLE
Only Perform PR Previews for notebooks, jb, and binder

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,10 @@
 name: Pull Request
 on:
   pull_request_target:
+    paths:
+      - 'notebooks/**'
+      - 'jupyterbook/**'
+      - 'binder/**'
     branches:
       - main
       


### PR DESCRIPTION
I notice that when emilio made a change to README it kicks the PR actions. With these changes, the PR Actions will only run for changes in `notebooks`, `jupyterbook` and `binder` folders.