### PR TITLE
Update OOI notebook to use distributed combine; bump echopype version to 0.6.3

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.9
   - ipykernel
-  - echopype=0.6.0
+  - echopype=0.6.3
   - s3fs
   - geopandas
   - cartopy


### PR DESCRIPTION
Not ready for review yet. Will update.

This PR includes:
- [x] update the echopype version
- [x] update the OOI notebook to include changed associated with distributed combine in the upcoming v0.6.3