### PR TITLE
Fix compute_MVBS argument in `echopype_tour.ipynb`

### DIFF
--- a/notebooks/echopype_tour.ipynb
+++ b/notebooks/echopype_tour.ipynb
@@ -7783,7 +7783,7 @@
     "Sv_ds = ep.calibrate.compute_Sv(combined_ed).compute()\n",
     "MVBS_ds = ep.commongrid.compute_MVBS(\n",
     "    Sv_ds,\n",
-    "    range_meter_bin=5,  # in meters\n",
+    "    range_bin= '5m',  # in meters\n",
     "    ping_time_bin='20s'  # in seconds\n",
     ")"
    ]


### PR DESCRIPTION
parameter range_bin should be str,  in function ep.commongrid.compute_MVBS(Sv_ds,
    range_bin= '5m',  # in meters
    ping_time_bin='20s'  # in seconds)