### PR TITLE
Update README and environment files

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,1 @@
+conda/environment.yml

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,1 +1,1 @@
-conda/environment.yml
+../conda/environment.yml

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ The examples are written as exectuable Jupyter Notebooks that you can easily run
 
 
 ### Quick glance via JupyterBook
-You can take a quick glance of the example notebooks at: https://osoceanacoustics.github.io/echopype-examples/
+You can see all example notebooks at: https://osoceanacoustics.github.io/echopype-examples/
 
 
-### Run the notebooks locally on your own machine
-If you want to run these notebooks on your own machine, we recommend the following steps:
+## Run the notebooks locally on your computer
+If you want to run these notebooks on your local computer, follow the steps below:
 - Clone and go into the repo
   ```shell
   # clone the repo
@@ -24,10 +24,10 @@ If you want to run these notebooks on your own machine, we recommend the followi
   # go into the repo folder
   cd echopype-examples
   ```
-- Create a conda environment using the `environment.yml` file in the `conda` folder. We recommend using mamba (see steps [here](https://github.com/conda-forge/miniforge#mambaforge) to install).
+- Create a conda environment using the `environment.yml` file in the `conda` folder. We recommend using Mamba (see steps [here](https://github.com/conda-forge/miniforge#mambaforge) to install).
   ```shell
   # create an environment
-  mamba env create -n echopype-examples -f binder/environment.yml
+  mamba env create -n echopype-examples -f conda/environment.yml
 
   # activate the environment
   conda activate echopype-examples
@@ -35,25 +35,26 @@ If you want to run these notebooks on your own machine, we recommend the followi
 - Try out the notebooks in the `notebooks` folder!
 
 
-### Run the notebooks on the cloud via Binder
-You can run the notebooks directly on the cloud using Mybinder.org, by:
-- clicking the "launch binder" bdage at the top of this page, or
-- clicking the "launch" icon (a rocket) on the upper right corner of each notebook in the JupyterBook
+## Run the notebooks on the cloud via Binder
+You can run the notebooks directly on the cloud using Mybinder.org, by clicking the "launch binder" badge at the top of this page.
 
 This will create a pre-configured JupyterLab with all the example notebooks under the `notebooks` folder. However, note that:
-- It usually takes a few minutes to spin up the Binder
-- The computational resources are very minimal on Binder, so the notebooks that handle many files may take very long or fail
+- It usually takes a few minutes to spin up Binder
+- The computational resources are very minimal on Binder, so some example notebooks that handle many files may take a very long time or fail
 - Any changes you make will not be saved
 
 
-### Contribute to the example notebooks!
+## Contribute to the example notebooks
 If you are interested in improving the existing notebooks or contributing new ones, awesome!
 
-The steps to set up a development environment is the same as the above. But: - If you want to use the latest changes in the Echopype repo, use `environment-ep-main.yml` when creating the conda environment
+The steps to set up a development environment is the same as the above. But:
+- If you want to use the latest changes in the Echopype `main` branch, use `conda/environment-ep-main.yml` when creating the conda environment
 - If you already have a functional Echopype development environment (see [here](https://echopype.readthedocs.io/en/stable/contributing.html#installation-for-echopype-development)) and want to use that, you can install additional packages needed for this repo by:
-  ```
+  ```shell
   conda install -c conda-forge geopandas cartopy datashader holoviews hvplot
   ```
+  Note that it is often cleaner and easier to just create a new environment.
+
 
 To build the JupyterBook locally:
 ```shell

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This repository hosts demonstration examples for [Echopype](https://echopype.readthedocs.io/en/stable/), an open-source Python library that enables scalable and interoperabe water column sonar data processing. 
 
-The examples are written as exectuable Jupyter Notebooks that you can easily run and modify on locally on your own machine or on the cloud.
+The examples are written as exectuable Jupyter Notebooks that you can easily run and modify on locally on your own machine or a cloud virtual machine.
 
 
 ## See all examples via JupyterBook
@@ -41,7 +41,7 @@ You can run the notebooks directly on the cloud using Mybinder.org, by clicking 
 This will create a pre-configured JupyterLab with all the example notebooks under the `notebooks` folder. However, note that:
 - It usually takes a few minutes to spin up Binder
 - The computational resources are very minimal on Binder, so some example notebooks that handle many files may take a very long time or fail
-- Any changes you make will not be saved
+- Any changes you make to the notebooks won't be saved permanently because Binder provides a temporary workspace
 
 
 ## Contribute to the example notebooks

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# echopype examples
+# echopype-examples
 
 [![Zenodo Badge](https://img.shields.io/badge/DOI-10.5281/zenodo.5618177-blue)](https://doi.org/10.5281/zenodo.5618177)
 [![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://tutorial.xarray.dev)
@@ -10,8 +10,8 @@ This repository hosts demonstration examples for [Echopype](https://echopype.rea
 The examples are written as exectuable Jupyter Notebooks that you can easily run and modify on locally on your own machine or on the cloud.
 
 
-### Quick glance via JupyterBook
-You can see all example notebooks at: https://osoceanacoustics.github.io/echopype-examples/
+## See all examples via JupyterBook
+All notebooks are rendered at: https://osoceanacoustics.github.io/echopype-examples/
 
 
 ## Run the notebooks locally on your computer
@@ -45,7 +45,7 @@ This will create a pre-configured JupyterLab with all the example notebooks unde
 
 
 ## Contribute to the example notebooks
-If you are interested in improving the existing notebooks or contributing new ones, awesome!
+Contributions are welcome and greatly appreciated!
 
 The steps to set up a development environment is the same as the above. But:
 - If you want to use the latest changes in the Echopype `main` branch, use `conda/environment-ep-main.yml` when creating the conda environment

--- a/README.md
+++ b/README.md
@@ -1,64 +1,68 @@
 # echopype examples
 
-<div>
-  <a href="https://doi.org/10.5281/zenodo.5618177">
-    <img src="https://img.shields.io/badge/DOI-10.5281/zenodo.5618177-blue" alt="DOI">
-  </a>
-
-  <a href="https://raw.githubusercontent.com/OSOceanAcoustics/echopype-examples/main/LICENSE">
-    <img alt="GitHub License" src="https://img.shields.io/github/license/OSOceanAcoustics/echopype-examples">
-  </a>
-</div>
-
+[![Zenodo Badge](https://img.shields.io/badge/DOI-10.5281/zenodo.5618177-blue)](https://doi.org/10.5281/zenodo.5618177)
+[![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://tutorial.xarray.dev)
+[![GitHub License](https://img.shields.io/github/license/OSOceanAcoustics/echopype-examples)](https://raw.githubusercontent.com/OSOceanAcoustics/echopype-examples/main/LICENSE)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/OSOceanAcoustics/echopype-examples/main?labpath=notebooks/index.ipynb)
 
-This repository illustrates the functionalities of [echopype](https://echopype.readthedocs.io/en/stable/), an open-source Python library that enables interoperability and scalability of water column sonar data processing. 
-The materials are presented as [Jupyter notebooks](https://realpython.com/jupyter-notebook-introduction/) (`.ipynb` files) in the [notebooks](https://github.com/OSOceanAcoustics/echopype-examples/tree/main/notebooks) folder.
- 
-## View the notebook collection rendered as a JupyterBook
-**Click [here](https://osoceanacoustics.github.io/echopype-examples/) to see the notebooks accurately rendered with a clean and convenient organization.**
+This repository hosts demonstration examples for [Echopype](https://echopype.readthedocs.io/en/stable/), an open-source Python library that enables scalable and interoperabe water column sonar data processing. 
 
-## Run the notebooks in Binder
-To actively explore and run the notebooks without downloading them or having to configure a Python environment locally, open them with [Binder](https://mybinder.org) either by clicking on the "launch binder" badge above to launch a sandbox copy or the "launch" icon (a rocket) on the upper right corner of each notebook in the JupyterBook. 
+The examples are written as exectuable Jupyter Notebooks that you can easily run and modify on locally on your own machine or on the cloud.
 
-The typical Binder start time is about 3 minutes. Once Binder finishes spinning up, try running the first notebook. Below are a few things to bear in mind:
-- The [index.md](https://github.com/OSOceanAcoustics/echopype-examples/blob/main/notebooks/index.md) file contains an index of the existing example notebooks with brief descriptions
-- Currently, some notebooks may fail to run to completion in Binder due to memory demands that exceed what is available on Binder
-- When you are done, just close the browser tab and the sandbox will be removed
 
-## Run the notebooks locally on your machine
-To run the notebooks locally in your computer, clone this repository (`git clone https://github.com/OSOceanAcoustics/echopype-examples.git`) and create a conda environment using the conda environment file [environment.yml](https://github.com/OSOceanAcoustics/echopype-examples/blob/main/binder/environment.yml) found in the `binder` folder:
+### Quick glance via JupyterBook
+You can take a quick glance of the example notebooks at: https://osoceanacoustics.github.io/echopype-examples/
 
-```bash
-conda env create -f environment.yml
-```
 
-This will create a new environment called `echopype.
+### Run the notebooks locally on your own machine
+If you want to run these notebooks on your own machine, we recommend the following steps:
+- Clone and go into the repo
+  ```shell
+  # clone the repo
+  git clone https://github.com/OSOceanAcoustics/echopype-examples.git
 
-## Set up a development environment to test and develop the notebooks and build the JupyterBook locally
-
-First, clone this repository (see section above). Then, decide what kind of `echopype` environment you'd like to use.
-### Use the latest echopype release
-To test and develop notebooks using the latest echopype release:
-- Follow the instructions above to create a conda environment.
-- Activate the new environment. Assuming you used the default environment name: `conda activate echopype`
-- Install `jupyter-book`: `conda install -c conda-forge jupyter-book`
-### Use the current echopype development branch
-To test and develop notebooks with the latest `echopype` development branch, go through the following steps:
-- Install an [echopype development environment](https://echopype.readthedocs.io/en/stable/contributing.html#installation-for-echopype-development). First, run this conda create command (or better yet, use [`mamba`](https://mamba.readthedocs.io) instead of `conda`):
-  ```bash
-  conda create -c conda-forge -n echopype --yes python=3.9 --file https://raw.githubusercontent.com/OSOceanAcoustics/echopype/dev/requirements.txt --file https://raw.githubusercontent.com/OSOceanAcoustics/echopype/dev/requirements-dev.txt --file https://raw.githubusercontent.com/OSOceanAcoustics/echopype/dev/docs/requirements.txt
+  # go into the repo folder
+  cd echopype-examples
   ```
-- Activate the new environment: `conda activate echopype`
-- Install additional packages:
-  ```bash
+- Create a conda environment using the `environment.yml` file in the `conda` folder. We recommend using mamba (see steps [here](https://github.com/conda-forge/miniforge#mambaforge) to install).
+  ```shell
+  # create an environment
+  mamba env create -n echopype-examples -f binder/environment.yml
+
+  # activate the environment
+  conda activate echopype-examples
+  ```
+- Try out the notebooks in the `notebooks` folder!
+
+
+### Run the notebooks on the cloud via Binder
+You can run the notebooks directly on the cloud using Mybinder.org, by:
+- clicking the "launch binder" bdage at the top of this page, or
+- clicking the "launch" icon (a rocket) on the upper right corner of each notebook in the JupyterBook
+
+This will create a pre-configured JupyterLab with all the example notebooks under the `notebooks` folder. However, note that:
+- It usually takes a few minutes to spin up the Binder
+- The computational resources are very minimal on Binder, so the notebooks that handle many files may take very long or fail
+- Any changes you make will not be saved
+
+
+### Contribute to the example notebooks!
+If you are interested in improving the existing notebooks or contributing new ones, awesome!
+
+The steps to set up a development environment is the same as the above. But: - If you want to use the latest changes in the Echopype repo, use `environment-ep-main.yml` when creating the conda environment
+- If you already have a functional Echopype development environment (see [here](https://echopype.readthedocs.io/en/stable/contributing.html#installation-for-echopype-development)) and want to use that, you can install additional packages needed for this repo by:
+  ```
   conda install -c conda-forge geopandas cartopy datashader holoviews hvplot
   ```
-- Run `pip install -e ".[plot]"`
 
-### Building the JupyterBook locally
-Regardless of which `echopype` environment you built:
+To build the JupyterBook locally:
+```shell
+# install jupyter book
+conda install -c conda-forge jupyter-book
 
-- Activate the new `echopype` environment
-- `cd` to your `echopype-examples` repository clone base folder, eg, `/path/to/clone/echopype-examples`
-- Build the jupyter book: `jupyter-book build notebooks`
+# go into the repo folder
+cd echopype-examples
+
+# build the jupyter book
+jupyter-book build notebooks
+```

--- a/conda/environment-ep-main.yml
+++ b/conda/environment-ep-main.yml
@@ -1,0 +1,19 @@
+name: echopype_examples
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.10
+  - ipykernel
+  - s3fs
+  - geopandas
+  - cartopy
+  - numba # Helps ensure a recent version is installed
+  # -- holoviz --
+  - datashader
+  - holoviews
+  - hvplot
+  # -- echopype --
+  # main branch (contains latest changes)
+  - pip:
+    - git+https://github.com/OSOceanAcoustics/echopype

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -16,6 +16,3 @@ dependencies:
   # -- echopype --
   # latest release
   - echopype=0.8.4
-  # main branch (contains new changes)
-  # - pip:
-  #   - git+https://github.com/OSOceanAcoustics/echopype


### PR DESCRIPTION
This PR addresses #46:
- overhaul README
- create `conda` folder and host 2 version of environment files that use different echopype versions
- rename `binder` to `.binder` and create symbolic link to link to `conda/environment.yml`