### PR TITLE
Update to use python 3.12 for the environment

### DIFF
--- a/conda/environment-ep-main.yml
+++ b/conda/environment-ep-main.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.10
+  - python=3.12
   - ipykernel
   - s3fs
   - geopandas

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.10
+  - python=3.12
   - ipykernel
   - s3fs
   - geopandas


### PR DESCRIPTION
This is to work with the upcoming echopype changes that will discontinue support for Python 3.10:
https://github.com/OSOceanAcoustics/echopype/issues/1541