### PR TITLE
ci: update Read the Docs to Python 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,27 +2,22 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
   jobs:
     pre_build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       - "jupyter-book config sphinx notebooks"
 
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: notebooks/conf.py
+  configuration: notebooks/conf.py
 
-# Optionally build your docs in additional formats such as PDF and ePub
 formats: []
 
-# Optionally set the version of Python and requirements required to build your docs
 python:
-   install:
-      - requirements: notebooks/requirements.txt
+  install:
+    - requirements: notebooks/requirements.txt


### PR DESCRIPTION
the previous build failed because a newly resolved dependency uses Python 3.10+ type-union syntax!